### PR TITLE
Coverages for different config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,24 +17,21 @@ jobs:
       - image: buildpack-deps:18.04
     steps:
       - checkout
-      - run: CFLAGS='-coverage' LDFLAGS='-lgcov' make -s
-      - run: gcov -abcflmpru $(find . -name '*.o')
+      - run: CFLAGS='-coverage' LDLIBS='-lgcov' make DST_DIR='build/coverage/default' -s
       - run: bash <(curl -s https://codecov.io/bash) || echo "Codecov did not collect coverage reports"
   coverage_debug:
     docker:
       - image: buildpack-deps:18.04
     steps:
       - checkout
-      - run: CFLAGS='-coverage -g -DDEBUG' LDFLAGS='-lgcov' make -s
-      - run: gcov -abcflmpru $(find . -name '*.o')
+      - run: CFLAGS='-coverage -g -DDEBUG' LDLIBS='-lgcov' make DST_DIR='build/coverage/debug' -s
       - run: bash <(curl -s https://codecov.io/bash) || echo "Codecov did not collect coverage reports"
   coverage_O2:
     docker:
       - image: buildpack-deps:18.04
     steps:
       - checkout
-      - run: CFLAGS='-coverage -O2' LDFLAGS='-lgcov' make -s
-      - run: gcov -abcflmpru $(find . -name '*.o')
+      - run: CFLAGS='-coverage -O2' LDLIBS='-lgcov' make DST_DIR='build/coverage/O2' -s
       - run: bash <(curl -s https://codecov.io/bash) || echo "Codecov did not collect coverage reports"
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,13 +5,35 @@ jobs:
       - image: buildpack-deps:18.04
     steps:
       - checkout
-      - run: CFLAGS=-coverage LDFLAGS=-fprofile-arcs make -s build
+      - run: make -s build
   test:
     docker:
       - image: buildpack-deps:18.04
     steps:
       - checkout
-      - run: CFLAGS=-coverage LDFLAGS=-fprofile-arcs make -s test
+      - run: make -s test
+  coverage_default:
+    docker:
+      - image: buildpack-deps:18.04
+    steps:
+      - checkout
+      - run: CFLAGS='-coverage' LDFLAGS='-lgcov' make -s
+      - run: gcov -abcflmpru $(find . -name '*.o')
+      - run: bash <(curl -s https://codecov.io/bash) || echo "Codecov did not collect coverage reports"
+  coverage_debug:
+    docker:
+      - image: buildpack-deps:18.04
+    steps:
+      - checkout
+      - run: CFLAGS='-coverage -g -DDEBUG' LDFLAGS='-lgcov' make -s
+      - run: gcov -abcflmpru $(find . -name '*.o')
+      - run: bash <(curl -s https://codecov.io/bash) || echo "Codecov did not collect coverage reports"
+  coverage_O2:
+    docker:
+      - image: buildpack-deps:18.04
+    steps:
+      - checkout
+      - run: CFLAGS='-coverage -O2' LDFLAGS='-lgcov' make -s
       - run: gcov -abcflmpru $(find . -name '*.o')
       - run: bash <(curl -s https://codecov.io/bash) || echo "Codecov did not collect coverage reports"
 workflows:
@@ -20,3 +42,8 @@ workflows:
     jobs:
       - build
       - test
+  coverage:
+    jobs:
+      - coverage_default
+      - coverage_debug
+      - coverage_O2


### PR DESCRIPTION
- reverted build and test jobs.
- added 3 type of coverage jobs:
  - default setting
  - debug setting (`-g -DDEBUG`)
  - O2 setting (`-O2`)
- fixed: use `-LDLIBS=lgcov` instead of `-LDFLAGS=...`
- removed `run: gcov` step since codecov runs gcov implicitly.