### PR TITLE
Full coverage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,13 @@ jobs:
       - checkout
       - run: CFLAGS='-coverage -O2' LDLIBS='-lgcov' make DST_DIR='build/coverage/O2' -s
       - run: bash <(curl -s https://codecov.io/bash) || echo "Codecov did not collect coverage reports"
+  coverage_full:
+    docker:
+      - image: buildpack-deps:18.04
+    steps:
+      - checkout
+      - run: CFLAGS='-coverage' LDFLAGS='-coverage' make DST_DIR='build/coverage/full' -s
+      - run: bash <(curl -s https://codecov.io/bash) || echo "Codecov did not collect coverage reports"
 workflows:
   version: 2
   build_and_test:
@@ -44,3 +51,4 @@ workflows:
       - coverage_default
       - coverage_debug
       - coverage_O2
+      - coverage_full

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,33 +12,12 @@ jobs:
     steps:
       - checkout
       - run: make -s test
-  coverage_default:
+  coverage:
     docker:
       - image: buildpack-deps:18.04
     steps:
       - checkout
-      - run: CFLAGS='-coverage' LDLIBS='-lgcov' make DST_DIR='build/coverage/default' -s
-      - run: bash <(curl -s https://codecov.io/bash) || echo "Codecov did not collect coverage reports"
-  coverage_debug:
-    docker:
-      - image: buildpack-deps:18.04
-    steps:
-      - checkout
-      - run: CFLAGS='-coverage -g -DDEBUG' LDLIBS='-lgcov' make DST_DIR='build/coverage/debug' -s
-      - run: bash <(curl -s https://codecov.io/bash) || echo "Codecov did not collect coverage reports"
-  coverage_O2:
-    docker:
-      - image: buildpack-deps:18.04
-    steps:
-      - checkout
-      - run: CFLAGS='-coverage -O2' LDLIBS='-lgcov' make DST_DIR='build/coverage/O2' -s
-      - run: bash <(curl -s https://codecov.io/bash) || echo "Codecov did not collect coverage reports"
-  coverage_full:
-    docker:
-      - image: buildpack-deps:18.04
-    steps:
-      - checkout
-      - run: CFLAGS='-coverage' LDFLAGS='-coverage' make DST_DIR='build/coverage/full' -s
+      - run: CFLAGS='-coverage' LDFLAGS='-coverage' make DST_DIR='build/coverage' -s
       - run: bash <(curl -s https://codecov.io/bash) || echo "Codecov did not collect coverage reports"
 workflows:
   version: 2
@@ -48,7 +27,4 @@ workflows:
       - test
   coverage:
     jobs:
-      - coverage_default
-      - coverage_debug
-      - coverage_O2
-      - coverage_full
+      - coverage

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,2 @@
+ignore:
+  - "thirdparty"		# ignore coverage of thirdparty's code


### PR DESCRIPTION
Added full coverage including unit-test code. (using `-LDFLAGS='-coverage'` instead of `-LDLIBS='gcov'`)
Three other kinds of coverage may not be necessary, do you?